### PR TITLE
Store stats in DB + protect production + increase timeout

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -117,14 +117,19 @@ jQuery(function ($) {
 
         $('#wpbody-content > div[id^="setting-error-"]').remove();
     }
-})
+
+    $('input[name*="storage_is_db"]').on('click', function () {
+        $('#storage_indicator').text(($(this).is(':checked') ? 'Yes, store in DB.' : 'No, write to disc.'));
+    });
+});
 
 /**
  * Generates a unique string in the form of a UUID
  * @returns string UUID
  */
 function uuidv4() {
-  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  );
+    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(
+        /[018]/g,
+        c => (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    );
 }

--- a/classes/ManageData.php
+++ b/classes/ManageData.php
@@ -78,7 +78,7 @@ class ManageData extends Admin
         echo '<input type="file" name="weighting-import" class="button-primary" /><br><br>';
 
         // Check and make dir if it doesn't exist
-        wp_mkdir_p(parent::importLocation());
+        wp_mkdir_p($this->importLocation());
     }
 
     /**

--- a/classes/Options.php
+++ b/classes/Options.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace MOJElasticSearch;
+
+class Options
+{
+    /**
+     * @var string prefix
+     */
+    public $prefix = 'moj_es';
+
+    /**
+     * @var null options > do not access directly, use $this->options()
+     */
+    protected $options = null;
+
+    /**
+     * @var int options
+     */
+    public $options_timer = 0;
+
+    /**
+     * @var string
+     */
+    public $option_name = '_settings';
+
+    /**
+     * @var string
+     */
+    public $option_group = '_plugin';
+
+    /**
+     * @var null
+     */
+    public $moj_bulk_index_stats = null;
+
+    /**
+     * @var boolean
+     */
+    public $stats_use_db = false;
+
+    /**
+     * @var array
+     */
+    public $stats = [];
+
+    /**
+     * @var array
+     */
+    public $stats_default = [
+        'total_bulk_requests' => 0,
+        'total_stored_requests' => 0,
+        'total_large_requests' => 0,
+        'bulk_body_size' => 0,
+        'bulk_request_errors' => [],
+        'large_files' => []
+    ];
+
+    public function __construct()
+    {
+        $this->stats_use_db = $this->options()['storage_is_db'] ?? false;
+        $this->options_timer = time();
+    }
+
+    /**
+     * Simple wrapper to fetch the plugins data array
+     * @return mixed|void
+     * @uses get_option()
+     */
+    public function options()
+    {
+        $this->optionsTimer();
+
+        if (!$this->options) {
+            $this->options = get_option($this->optionName(), []);
+        }
+
+        return $this->options;
+    }
+
+    /**
+     * Simple wrapper to fetch the plugins data array
+     * @return mixed|void
+     * @uses get_option()
+     */
+    public function statsDB()
+    {
+        if (!$this->stats) {
+            $this->stats = get_option('_moj_bulk_index_stats', $this->stats_default);
+        }
+
+        return $this->stats;
+    }
+
+    /**
+     * Manages the refresh rate of cached plugin options and prevents too many DB requests
+     * @return bool
+     */
+    private function optionsTimer()
+    {
+        // refresh options array after 5 seconds
+        if (time() - $this->options_timer > 5) {
+            $this->options_timer = time();
+            $this->options = null;
+            return true;
+        }
+    }
+
+    /**
+     * Get the option group for the plugin settings. Used as 'page' in register_settings()
+     * @return string
+     */
+    public function optionGroup()
+    {
+        return $this->prefix . $this->option_group;
+    }
+
+    /**
+     * The settings name for our plugins option data.
+     * Calling get_option() with this string will produce the plugins data.
+     * @return string
+     */
+    public function optionName()
+    {
+        return $this->prefix . $this->option_name;
+    }
+
+    /**
+     * Update a setting value using the WP Settings API
+     * @param $key
+     * @param $value
+     * @return bool
+     */
+    public function updateOption($key, $value)
+    {
+        $options = $this->options();
+
+        $options[$key] = $value;
+        return update_option($this->optionName(), $options);
+    }
+
+    /**
+     * Delete a setting value using the WP Settings API
+     * @param $key
+     * @return bool
+     */
+    public function deleteOption($key)
+    {
+        $options = $this->options();
+
+        unset($options[$key]);
+        return update_option($this->optionName(), $options);
+    }
+
+    /**
+     * Get the stats stored in options or from disc
+     * @return array|string|null
+     */
+    public function getStats()
+    {
+        if ($this->moj_bulk_index_stats) {
+            return $this->moj_bulk_index_stats;
+        }
+
+        if ($this->stats_use_db) {
+            return $this->statsDB();
+        }
+
+        // if not present, create the default stats file.
+        if (!file_exists($this->importLocation() . 'moj-bulk-index-stats.json')) {
+            $this->setStats($this->stats_default);
+        }
+
+        // finally, get from the file system
+        return (array)json_decode(file_get_contents($this->importLocation() . 'moj-bulk-index-stats.json'));
+    }
+
+    public function setStats($es_stats)
+    {
+        $this->moj_bulk_index_stats = $es_stats;
+
+        if ($this->stats_use_db) {
+            update_option('_moj_bulk_index_stats', $es_stats);
+            return $es_stats;
+        }
+
+        // storage is file system
+        $handle = fopen($this->importLocation() . 'moj-bulk-index-stats.json', 'w');
+        fwrite($handle, json_encode($es_stats));
+        fclose($handle);
+    }
+
+    /**
+     * @return bool if stats were cleared
+     */
+    public function clearStats()
+    {
+        if ($this->stats_use_db) {
+            $this->moj_bulk_index_stats = null;
+            return update_option('_moj_bulk_index_stats', $this->stats_default);
+        }
+
+        return unlink($this->importLocation() . 'moj-bulk-index-stats.json');
+    }
+
+    /**
+     * Defines the import data location in the uploads directory.
+     * @return string
+     */
+    public function importLocation()
+    {
+        $file_dir = get_temp_dir();
+        return $file_dir . basename(plugin_dir_path(dirname(__FILE__, 1))) . DIRECTORY_SEPARATOR;
+    }
+}

--- a/traits/Settings.php
+++ b/traits/Settings.php
@@ -36,31 +36,4 @@ trait Settings
             }
         }
     }
-
-    /**
-     * Update a setting value using the WP Settings API
-     * @param $key
-     * @param $value
-     * @return bool
-     */
-    public function updateOption($key, $value)
-    {
-        $options = $this->options();
-
-        $options[$key] = $value;
-        return update_option($this->optionName(), $options);
-    }
-
-    /**
-     * Delete a setting value using the WP Settings API
-     * @param $key
-     * @return bool
-     */
-    public function deleteOption($key)
-    {
-        $options = $this->options();
-
-        unset($options[$key]);
-        return update_option($this->optionName(), $options);
-    }
 }

--- a/wp-moj-elasticsearch.php
+++ b/wp-moj-elasticsearch.php
@@ -14,6 +14,7 @@
 // Load all our classes from PSR4 autoloader
 require(MOJ_ROOT_DIR . '/vendor/autoload.php');
 
+use MOJElasticSearch\Options;
 use MOJElasticSearch\Admin;
 use MOJElasticSearch\Auth;
 use MOJElasticSearch\ElasticPressHooks;
@@ -22,6 +23,7 @@ use MOJElasticSearch\ManageData;
 use MOJElasticSearch\SignAmazonEsRequests;
 
 if (new Auth) {
+    new Options;
     new Admin;
     new SignAmazonEsRequests;
     new ElasticPressHooks;


### PR DESCRIPTION
Indexing
- Stats can now be stored in the DB or file system
- Production is time protected against bulk indexing and will only start indexing after midnight and before 7:30am
- - time protection is managed by a schedule that is registered when a user requests a reindex
- POST request timeout has been increased to 1 minute 30 seconds to allow large payloads on staging/production
- New Options.php file created to minimise code-read confusion in other classes