### PR TITLE
Remove custom AWS synonym mapping

### DIFF
--- a/classes/ElasticPressHooks.php
+++ b/classes/ElasticPressHooks.php
@@ -36,7 +36,6 @@ class ElasticPressHooks
         add_filter('ep_index_name', [$this, 'aliasName'], 10, 1);
         add_filter('ep_prepare_meta_excluded_public_keys', [$this, 'excludeMetaMappingFields'], 10, 2);
         add_filter('ep_index_default_per_page', [$this, 'indexPerPage'], 10, 1);
-        add_filter('ep_config_mapping', [$this, 'mapCustomConfig'], 10, 1);
         add_filter('ep_config_mapping_request', [$this, 'mapRequest'], 10, 1);
         add_filter('ep_post_sync_args_post_prepare_meta', [$this, 'removePostArgs'], 10, 2);
     }
@@ -126,62 +125,6 @@ class ElasticPressHooks
     {
         echo 'ElasticSearch Response: ' . $request['body'] . PHP_EOL;
         return $request;
-    }
-
-    /**
-     * Add custom configurations to ElasticSearch mapping
-     * @param array
-     * @return array
-     */
-    public function mapCustomConfig(array $mapping): array
-    {
-        // Check mapping exists in the expected data type
-        if (!isset($mapping) || !is_array($mapping)) {
-            echo 'Error mapping issue, mapping does not appear to exist.';
-            return $mapping;
-        }
-
-        /**
-         * Add custom synonym filter using AWS packages
-         * https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/custom-packages.html
-         * */
-        $mapping['settings']['analysis']['filter']['moj_es_plugin_synonyms'] = [
-            'type' => 'synonym',
-            'synonyms_path' => 'analyzers/F124583324'
-        ];
-
-        // Create a custom analyzer we can add our own filters to as required
-        $mapping['settings']['analysis']['analyzer']['moj_analyzer'] = [
-            'type' => 'custom',
-            'char_filter' => 'html_strip',
-            "language" => "english",
-            'tokenizer' => 'standard',
-            'filter' => [
-                'lowercase',
-                'stop',
-                'ewp_snowball',
-                'moj_es_plugin_synonyms'
-            ]
-        ];
-
-        $default_filter_array = $mapping['settings']['analysis']['analyzer']['default']['filter'];
-
-        // Check default filter has been created by ElasticPress plugin as we need to add to it
-        if (!isset($default_filter_array) || !is_array($default_filter_array)) {
-            echo 'Error mapping issue, default filter is missing.';
-            return $mapping;
-        }
-
-        /**
-         * Add the custom synonym filter to the default EP plugin analyzer.
-         * Synonym filter needs to be first in array as it is not compatible with ewp_word_delimiter being first
-         * */
-        $mapping['settings']['analysis']['analyzer']['default']['filter'] = array_merge(
-            ['moj_es_plugin_synonyms'],
-            $default_filter_array
-        );
-
-        return $mapping;
     }
 
     /**


### PR DESCRIPTION
Synonyms functionality has now been added to the ElasticPress plugin so
we don't have to have our own custom method for adding them in.